### PR TITLE
Unsupport CommonJS style and support ES style Module Import

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es2015", "dom"],
-    "module": "umd",
+    "module": "esnext",
     "moduleResolution": "node",
     "jsx": "react",
     "jsxFactory": "createElement",


### PR DESCRIPTION
To optimize dynamic import, I've decided to unsupport CommonJS style import and make the built code ES import. I think almost all of developers use this library with some module bundler which is supporting ES import such as webpack. So CommonJS style is unnecessary.